### PR TITLE
Add delete functionality for VoltageTransformer entity

### DIFF
--- a/src/function/cim/OldPotentialTransformerInfo/index.js
+++ b/src/function/cim/OldPotentialTransformerInfo/index.js
@@ -105,6 +105,8 @@ export const updateOldPotentialTransformerInfoTransaction = async (mrid, info, d
 
 // Xóa oldPotentialTransformerInfo (transaction)
 export const deleteOldPotentialTransformerInfoTransaction = async (mrid, dbsql) => {
+    console.log("Deleting OldPotentialTransformerInfo:", mrid);
+
     return new Promise(async (resolve, reject) => {
         try {
             const ptInfoResult = await PotentialTransformerInfoFunc.deletePotentialTransformerInfoTransaction(mrid, dbsql)

--- a/src/function/cim/PotentialTransformerInfo/index.js
+++ b/src/function/cim/PotentialTransformerInfo/index.js
@@ -110,6 +110,8 @@ export const updatePotentialTransformerInfoTransaction = async (mrid, info, dbsq
 
 // Xóa potentialTransformerInfo (transaction)
 export const deletePotentialTransformerInfoTransaction = async (mrid, dbsql) => {
+    console.log("Deleting PotentialTransformerInfo:", mrid);
+
     return new Promise(async (resolve, reject) => {
         try {
             const assetInfoResult = await AssetInfoFunc.deleteAssetInfoByIdTransaction(mrid, dbsql)

--- a/src/ipcmain/entity/VoltageTransformer/index.js
+++ b/src/ipcmain/entity/VoltageTransformer/index.js
@@ -6,7 +6,6 @@ export const insertVoltageTransformerEntity = () => {
     ipcMain.handle('insertVoltageTransformerEntity', async function (event, old_data, data) {
         try {
 
-            console.log('Point 2');
             const rs = await entityFunc.voltageTransformerEntityFunc.insertVoltageTransformerEntity(old_data, data)
             if (rs.success == true) {
                 return {
@@ -60,7 +59,35 @@ export const getVoltageTransformerEntityByMrid = () => {
     })
 }
 
+export const deleteVoltageTransformerEntity = () => {
+    ipcMain.handle('deleteVoltageTransformerEntity', async function (event, data) {
+        try {
+            const rs = await entityFunc.voltageTransformerEntityFunc.deleteVoltageTransformerEntity(data)
+            if (rs.success == true) {
+                return {
+                    success: true,
+                    message: "Success",
+                    data : data
+                }
+            }
+            else {
+                return {
+                    success: false,
+                    message: "fail",
+                }
+            }
+        } catch (error) {
+            return {
+                error: error,
+                success: false,
+                message: (error && error.message) ? error.message : "Internal error",
+            }
+        }
+    })
+}
+
 export const active = () => {
     insertVoltageTransformerEntity()
     getVoltageTransformerEntityByMrid()
+    deleteVoltageTransformerEntity()
 }

--- a/src/preload/entity/VoltageTransformer/index.js
+++ b/src/preload/entity/VoltageTransformer/index.js
@@ -4,5 +4,6 @@ export const voltageTransformerEntityPreload = () => {
     return {
         insertVoltageTransformerEntity: (old_data, data) => ipcRenderer.invoke('insertVoltageTransformerEntity', old_data, data),
         getVoltageTransformerEntityByMrid : (mrid, psr_id) => ipcRenderer.invoke('getVoltageTransformerEntityByMrid', mrid, psr_id),
+        deleteVoltageTransformerEntity : (data) => ipcRenderer.invoke('deleteVoltageTransformerEntity', data),
     }
 }

--- a/src/views/TreeNode/treeNavigation.vue
+++ b/src/views/TreeNode/treeNavigation.vue
@@ -820,29 +820,29 @@ export default {
                 mode: ''
             },
             terminal: {
-        rated_u: { value: '' },
-        bil: { value: '' },
-        bsl: { value: '' },
-        type: { value: '' },
-        class: { value: '' },
-        connector_type: { value: '' },
-        service_condition: { value: '' }
-      },
-      joint: {
-        rated_u: { value: '' },
-        rated_current: { value: '' },
-        category: { value: '' },
-        construction: { value: '' },
-        service_condition: { value: '' }
-      },
-      sheath_limits: {
-        rated_voltage_ur: { value: '' },
-        max_continuous_operating_voltage: { value: '' },
-        nominal_discharge_current: { value: '' },
-        high_current_impulse_withstand: { value: '' },
-        long_duration_current_impulse_withstand: { value: '' },
-        short_circuit: { value: '' }
-      },
+                rated_u: { value: '' },
+                bil: { value: '' },
+                bsl: { value: '' },
+                type: { value: '' },
+                class: { value: '' },
+                connector_type: { value: '' },
+                service_condition: { value: '' }
+            },
+            joint: {
+                rated_u: { value: '' },
+                rated_current: { value: '' },
+                category: { value: '' },
+                construction: { value: '' },
+                service_condition: { value: '' }
+            },
+            sheath_limits: {
+                rated_voltage_ur: { value: '' },
+                max_continuous_operating_voltage: { value: '' },
+                nominal_discharge_current: { value: '' },
+                high_current_impulse_withstand: { value: '' },
+                long_duration_current_impulse_withstand: { value: '' },
+                short_circuit: { value: '' }
+            },
             sl: 10,
             count: '',
             ownerServerList: [],
@@ -866,7 +866,7 @@ export default {
         }
     },
     methods: {
-        
+
         async reloadLogClient(doneCallback) {
             try {
                 const data = await window.electronAPI.getAllConfigurationEvents()
@@ -2702,6 +2702,31 @@ export default {
                                 }
                                 console.log('Disconnector entity:', entity)
                                 const deleteSign = await window.electronAPI.deleteDisconnectorEntity(entity.data);
+                                if (!deleteSign.success) {
+                                    this.$message.error("Delete data failed: " + (deleteSign.message || 'Unknown error'));
+                                    return;
+                                }
+                                // ✅ Xóa node khỏi cây organisationClientList
+                                const parentNode = this.findNodeById(node.parentId, this.organisationClientList);
+                                if (parentNode && Array.isArray(parentNode.children)) {
+                                    const index = parentNode.children.findIndex(child => child.mrid === node.mrid);
+                                    if (index !== -1) {
+                                        parentNode.children.splice(index, 1); // Xóa khỏi mảng children
+                                        this.$message.success("Delete data successfully");
+                                    } else {
+                                        this.$message.warning("Node not found in tree structure");
+                                    }
+                                } else {
+                                    this.$message.warning("Parent node not found in tree");
+                                }
+                            } else if (node.asset === 'Voltage transformer') {
+                                const entity = await window.electronAPI.getVoltageTransformerEntityByMrid(node.mrid, node.parentId);
+                                if (!entity.success) {
+                                    this.$message.error("Entity not found");
+                                    return;
+                                }
+                                console.log('Voltage transformer entity:', entity)
+                                const deleteSign = await window.electronAPI.deleteVoltageTransformerEntity(entity.data);
                                 if (!deleteSign.success) {
                                     this.$message.error("Delete data failed: " + (deleteSign.message || 'Unknown error'));
                                     return;


### PR DESCRIPTION
Implemented backend and frontend logic to delete VoltageTransformer entities, including related assets and attachments. Updated IPC, preload, and tree navigation components to support entity deletion and tree node removal.